### PR TITLE
second argument for import is resource_id

### DIFF
--- a/stone_burner/config.py
+++ b/stone_burner/config.py
@@ -34,7 +34,7 @@ OPTIONS_BY_COMMAND = {
     },
     'import': {
         'options': ['var-file', 'state'],
-        'args': ['address', 'id'],
+        'args': ['address', 'resource_id'],
     },
     'validate': {
         'options': ['var-file', 'check-variables'],
@@ -207,9 +207,9 @@ class TFAttributes(object):
         return [kwargs['address']]
 
     @staticmethod
-    def id(*args, **kwargs):
+    def resource_id(*args, **kwargs):
         #pylint: disable=unused-argument
-        return [kwargs['id']]
+        return [kwargs['resource_id']]
 
     @staticmethod
     def check_variables(*args, **kwargs):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/bin/stone-burner", line 11, in <module>
    sys.exit(main())
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/stone_burner/cli.py", line 240, in tf_import_cmd
    **kwargs,
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/stone_burner/lib.py", line 208, in run
    **kwargs
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/stone_burner/lib.py", line 126, in build_command
    values = func(TFAttributes(), *args, **kwargs)
  File "/Users/emilien/.local/share/virtualenvs/devops-terraform-3gug9M3l/lib/python3.6/site-packages/stone_burner/config.py", line 212, in id
    return [kwargs['id']]
KeyError: 'id'
```